### PR TITLE
 Spill rbx register before test writes

### DIFF
--- a/test/x64/basic-test.js
+++ b/test/x64/basic-test.js
@@ -79,22 +79,26 @@ describe('JIT.js x64 Basics', function() {
   }, 42);
 
   test('should support movzxb/movzxw', function() {
-    this.mov('rbx', 0xdeadbeef);
-    this.push('rbx');
-    this.movzxb('rax', [ 'rsp', 0 ]);
-    this.movzxw('rbx', [ 'rsp', 0 ]);
-    this.add('rax', 'rbx');
-    this.pop('rbx');
+    this.spill('rbx', function() {
+      this.mov('rbx', 0xdeadbeef);
+      this.push('rbx');
+      this.movzxb('rax', [ 'rsp', 0 ]);
+      this.movzxw('rbx', [ 'rsp', 0 ]);
+      this.add('rax', 'rbx');
+      this.pop('rbx');
 
-    this.Return();
+      this.Return();
+    });
   }, 0xef + 0xbeef);
 
   test('should support movl', function() {
-    this.mov('rbx', new Buffer('78563412efcdab90', 'hex'));
-    this.push('rbx');
-    this.movl('rax', [ 'rsp', 0 ]);
-    this.pop('rbx');
+    this.spill('rbx', function() {
+      this.mov('rbx', new Buffer('78563412efcdab90', 'hex'));
+      this.push('rbx');
+      this.movl('rax', [ 'rsp', 0 ]);
+      this.pop('rbx');
 
-    this.Return();
+      this.Return();
+    });
   }, 0x12345678);
 });


### PR DESCRIPTION
On 64-bit Linux (tested with Fedora 22), a couple jit.js tests that utilize the `rbx` register segfault.
- `"should support movzxb/movzxw"`
- `"should support movl"`

Interestingly enough, these failures do not appear on OS X (10.10) or while building in debug mode. After talking with @indutny, by convention `rbx` should not be overwritten and the discrepancy between test failures could stem from the compiler+optimizations being used.  Nonetheless, this change fixes those tests across either OS/compiler.
